### PR TITLE
Upgrade to elasticmq version 0.13.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM frolvlad/alpine-oraclejdk8:slim
 MAINTAINER Bryan Talbot <bryan.talbot@ijji.com>
 EXPOSE 9324
 
-ENV ELASTICMQ_VERSION=0.12.0 \
+ENV ELASTICMQ_VERSION=0.13.0 \
     ELASTICMQ_SHA256=06c6b5dcf0d2f7efdbbeca466917a0345bc71fbccaf1282e74b14e596cd2b215
 
 # Download and install the binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM frolvlad/alpine-oraclejdk8:slim
 MAINTAINER Bryan Talbot <bryan.talbot@ijji.com>
 EXPOSE 9324
 
-ENV ELASTICMQ_VERSION=0.13.0 \
-    ELASTICMQ_SHA256=06c6b5dcf0d2f7efdbbeca466917a0345bc71fbccaf1282e74b14e596cd2b215
+ENV ELASTICMQ_VERSION=0.13.2 \
+    ELASTICMQ_SHA256=6f038e3eb105c3de3de8a387e4360335e35ab8cc21575749b58eedfd19abe28f
 
 # Download and install the binaries
 RUN wget -q -O /elasticmq-server.jar http://s3-eu-west-1.amazonaws.com/softwaremill-public/elasticmq-server-${ELASTICMQ_VERSION}.jar && \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A docker container for [elasticmq](https://github.com/adamw/elasticmq) which is 
 It's on [docker-hub](https://hub.docker.com/r/fingershock/elasticmq/) and [github](https://github.com/iJJi/docker-elasticmq)
 
 ## tags and links
- * `latest`, `0.12.0` [(Dockerfile)](https://github.com/ijji/docker-elasticmq/blob/master/Dockerfile) [![](https://badge.imagelayers.io/fingershock/elasticmq:latest.svg)](https://imagelayers.io/?images=fingershock/elasticmq:latest) [![Build Status](https://travis-ci.org/iJJi/docker-elasticmq.svg?branch=master)](https://travis-ci.org/iJJi/docker-elasticmq)
+ * `latest`, `0.13.2` [(Dockerfile)](https://github.com/ijji/docker-elasticmq/blob/master/Dockerfile) [![](https://badge.imagelayers.io/fingershock/elasticmq:latest.svg)](https://imagelayers.io/?images=fingershock/elasticmq:latest) [![Build Status](https://travis-ci.org/iJJi/docker-elasticmq.svg?branch=master)](https://travis-ci.org/iJJi/docker-elasticmq)
 
 ## running
 


### PR DESCRIPTION
This is a simple PR to upgrade elasticmq to latest version (0.13.2).

I've just updated the `ELASTICMQ_VERSION` and `ELASTICMQ_SHA256`  to be compatible with latest version.